### PR TITLE
Include .esql and .subflow files in copyBuildFilesTask()

### DIFF
--- a/src/main/groovy/com/ibm/gradle/plugins/ace/tasks/CopyBuildFilesTask.groovy
+++ b/src/main/groovy/com/ibm/gradle/plugins/ace/tasks/CopyBuildFilesTask.groovy
@@ -47,6 +47,7 @@ abstract class CopyBuildFilesTask extends Copy {
         include '**/*.msgflow'
         include '**/*.json'
         include '**/*.policyxml'
+        include '**/*.esql'
         include '**/.project'
 
         Task jarTask = project.tasks.findByName('jar')

--- a/src/main/groovy/com/ibm/gradle/plugins/ace/tasks/CopyBuildFilesTask.groovy
+++ b/src/main/groovy/com/ibm/gradle/plugins/ace/tasks/CopyBuildFilesTask.groovy
@@ -48,6 +48,7 @@ abstract class CopyBuildFilesTask extends Copy {
         include '**/*.json'
         include '**/*.policyxml'
         include '**/*.esql'
+        include '**/*.subflow'
         include '**/.project'
 
         Task jarTask = project.tasks.findByName('jar')


### PR DESCRIPTION
Currently when building the app, esql files are left out creating errors. I think this is where the change is needed :)